### PR TITLE
Update to new EVM-C API

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -34,12 +34,23 @@ def test_evm():
 
     gas = 200000
 
+    success = evm.set_option("hello", "world")
+    assert not success
+
+    ready = evm.is_code_ready(evm_mode.EVM_HOMESTEAD, code_hash)
+    assert not ready
+
+    evm.prepare_code(evm_mode.EVM_HOMESTEAD, code_hash, code)
+
+    ready = evm.is_code_ready(evm_mode.EVM_HOMESTEAD, code_hash)
+    assert ready
+
     # import pdb; pdb.set_trace()
     env = {'name': "Env"}  # You can pass any Python object as env argument.
     result = evm.evm_execute(env, evm_mode.EVM_HOMESTEAD, code_hash, code, gas,
                              input, value_ffi)
 
-    evm.evm_destroy_result(result)
+    evm.evm_release_result(result)
     evm.evm_destroy()
 
 


### PR DESCRIPTION
Update to the latest state of art of EVM-C API (https://github.com/ethereum/evmjit/commit/e9a1344008a11fd46fee8be70dfc3ce1959e84d5).
No more big changes planned, just some small tweaks to improve Python interfacing. See https://github.com/ethereum/evmjit/issues/88.